### PR TITLE
deleted unneccessary service file

### DIFF
--- a/spacelift-impl/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/spacelift-impl/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,1 +1,0 @@
-org.arquillian.spacelift.ArquillianSpaceliftExtension


### PR DESCRIPTION
@kpiwko 

when this file is not deleted, I can not use Spacelift with Arquillian, because it tries to load nonexisting class so exception is thrown. Relates to #26 

I can not update e.g. Droidium to Spacelift Alpha5 (respectively 6) until this is merged and released. I could provide fake service just to make it pass but it is obviously temporary and ugly hack.