### PR TITLE
Replaced File.mkdirs with FileUtils.mkdir of Apache Commons IO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <version.hamcrest>1.3</version.hamcrest>
     <version.commons.lang>3.3.1</version.commons.lang>
     <version.mockito>2.7.14</version.mockito>
+    <version.commons.io>2.5</version.commons.io>
 
     <maven.compiler.target>1.6</maven.compiler.target>
     <maven.compiler.source>1.6</maven.compiler.source>
@@ -69,6 +70,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${version.commons.lang}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${version.commons.io}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/spacelift-api/pom.xml
+++ b/spacelift-api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/spacelift-api/src/main/java/org/arquillian/spacelift/Spacelift.java
+++ b/spacelift-api/src/main/java/org/arquillian/spacelift/Spacelift.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.io.FileUtils;
 import org.arquillian.spacelift.Invokable.InvocationException;
 import org.arquillian.spacelift.execution.ExecutionService;
 import org.arquillian.spacelift.task.InjectTask;
@@ -170,10 +171,10 @@ public class Spacelift {
         }
 
         @Override
-        public File cache() {
+        public File cache() throws IOException {
             String userHome = System.getProperty("user.home", ".");
             File cache = new File(userHome, ".spacelift/cache");
-            cache.mkdirs();
+            FileUtils.forceMkdir(cache);
             return cache;
         }
 
@@ -188,7 +189,7 @@ public class Spacelift {
         }
 
         @Override
-        public File cachePath(String path) throws IllegalArgumentException {
+        public File cachePath(String path) throws IllegalArgumentException, IOException {
 
             if (path == null) {
                 throw new IllegalArgumentException("Path must not be null.");

--- a/spacelift-api/src/main/java/org/arquillian/spacelift/SpaceliftConfiguration.java
+++ b/spacelift-api/src/main/java/org/arquillian/spacelift/SpaceliftConfiguration.java
@@ -1,6 +1,7 @@
 package org.arquillian.spacelift;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * Spacelift configuration.
@@ -22,8 +23,10 @@ public interface SpaceliftConfiguration {
      * Returns a directory where Spacelift caches task artifacts so they can be reused by all builds.
      * <p>
      * By default, this is $USER_DIR/.spacelift
+     * @throws IOException if an I/O exception occured during creation of the
+     * cache directory
      */
-    File cache();
+    File cache() throws IOException;
 
     /**
      * Returns a path in workspace
@@ -44,6 +47,8 @@ public interface SpaceliftConfiguration {
      *
      * @throws IllegalArgumentException
      *     if path is null
+     * @throws IOException if an I/O exception occured during creation of the
+     * cache directory
      */
-    File cachePath(String path) throws IllegalArgumentException;
+    File cachePath(String path) throws IllegalArgumentException, IOException;
 }

--- a/spacelift-impl/pom.xml
+++ b/spacelift-impl/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/spacelift-impl/src/main/java/org/arquillian/spacelift/task/archive/UncompressTool.java
+++ b/spacelift-impl/src/main/java/org/arquillian/spacelift/task/archive/UncompressTool.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.io.FileUtils;
 import org.arquillian.spacelift.task.Task;
 import org.arquillian.spacelift.task.text.ReplacementTuple;
 
@@ -105,11 +106,10 @@ public abstract class UncompressTool extends Task<File, File> {
             File file = new File(this.dest, remapEntryName(entry.getName()));
 
             if (entry.isDirectory()) {
-                file.mkdirs();
+                FileUtils.forceMkdir(file);
             } else {
-
                 if (!file.getParentFile().exists()) {
-                    file.getParentFile().mkdirs();
+                    FileUtils.forceMkdir(file.getParentFile());
                 }
 
                 int count;


### PR DESCRIPTION
Replaced File.mkdirs with FileUtils.mkdir of Apache Commons IO in order to notice failure of directory creation which is easier with IOException than the boolean return value of File.mkdirs (which has been ignored so far anyway).

#### Short description of what this resolves:
Ignored failures of `java.io.File.mkdirs` which would require handling of the boolean return value which is already done in Apache Commons IO.

This requires throwing `IOException` in `SpaceliftConfiguration.cache` and `cachePath(String)`, but that's necessary anyway since ignoring the failure of directory creation which would lead to bizarre behaviour (which has been the motivation for this PR, see e.g. https://stackoverflow.com/questions/47217087/why-does-my-arquillian-drone-functional-test-not-work-on-gitlab-ci) is not an option.

Since the `if (!file.getParentFile().exists())` branch in `UncompressTool.process` isn't covered by a unit test, yet, I'd be happy for a suggestion how to acchieve that (in the linked SO question the failure is caused by a failure to create the directory at the statement wrapped with the mentioned if condition).

I have no idea why Travis CI fails (complains about erroneous `JAVA_HOME`, while the main repo passes.

#### Changes proposed in this pull request:

- replacement of `File.mkdirs` with `FileUtils.mkdir` of Apache Commons IO
